### PR TITLE
Schedule Extraction to CSV file

### DIFF
--- a/web-extension/popup.css
+++ b/web-extension/popup.css
@@ -54,10 +54,28 @@
     filter: drop-shadow(0 2px 4px rgba(45, 35, 66, 0.4));
 }
 
+#dateInput:disabled {
+    background-color: #e4e2e2;
+    color: rgba(0, 0, 0, 0.3);
+    cursor: not-allowed;
+}
+
+.convert-container {
+    position: relative;
+    width: 75%;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: #FCFCFD;
+    border-radius: 4px;
+}
+
 #convertButton {
+    flex: 75;
     align-items: center;
     appearance: none;
-    background-color: #FCFCFD;
+    /* background-color: #FCFCFD; */
     border-radius: 4px;
     border-width: 0;
     box-shadow: rgba(45, 35, 66, 0.4) 0 2px 4px,rgba(45, 35, 66, 0.3) 0 7px 13px -3px,#D6D6E7 0 -3px 0 inset;
@@ -85,17 +103,29 @@
 }
 
 #convertButton {
-box-shadow: #D6D6E7 0 0 0 1.5px inset, rgba(45, 35, 66, 0.4) 0 2px 4px, rgba(45, 35, 66, 0.3) 0 7px 13px -3px, #D6D6E7 0 -3px 0 inset;
+    box-shadow: #D6D6E7 0 0 0 1.5px inset, rgba(45, 35, 66, 0.4) 0 2px 4px, rgba(45, 35, 66, 0.3) 0 7px 13px -3px, #D6D6E7 0 -3px 0 inset;
 }
 
 #convertButton:hover {
-box-shadow: rgba(45, 35, 66, 0.4) 0 4px 8px, rgba(45, 35, 66, 0.3) 0 7px 13px -3px, #D6D6E7 0 -3px 0 inset;
-transform: translateY(-2px);
+    box-shadow: rgba(45, 35, 66, 0.4) 0 4px 8px, rgba(45, 35, 66, 0.3) 0 7px 13px -3px, #D6D6E7 0 -3px 0 inset;
+    transform: translateY(-2px);
 }
 
-#convertButton:active {
-box-shadow: #D6D6E7 0 3px 7px inset;
-transform: translateY(2px);
+#convertButton:active{
+    box-shadow: #D6D6E7 0 3px 7px inset;
+    transform: translateY(2px);
+}
+
+#fileType {
+    height: 30px;
+    flex: 25;
+    outline: 0px;
+    border: 0px;
+    box-shadow: none;
+    appearance: none;
+    box-sizing: border-box;
+    color: #36395A;
+    text-align: center;
 }
 
 .btn-txt{

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -16,7 +16,14 @@
                 <label for="dateInput"> <p class="label-text">Select end date of recurring schedule:</p></label>
                 <input type="date" id="dateInput" name="dateInput">
             </div>
-            <button id="convertButton"><span class="btn-txt">Convert to .ics</span></button>
+            <div class="convert-container">
+                <button id="convertButton"><span class="btn-txt">Convert to</span></button>
+                <select name="file-type" id="fileType">
+                    <option value="ics" selected>.ics</option>
+                    <option value="csv">.csv</option>
+                </select>
+            </div>
+            
         </div>
 
             <div id="display-box">

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -34,16 +34,42 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     }
 
     else {
-      const output = separateSchedules(request.schedule);
-      const iCalData = jsonToICal(output);
-      downloadICS(iCalData, "schedule");
 
-      newTag.textContent = "ICalendar file (.ics) downloaded!";
+      const output = separateSchedules(request.schedule);
+
+      // This will first convert the data into the preferred file format 
+      // and then proceed to initiate the download of the converted data
+      let data;
+      let textContent;
+      if (preferredFileType === 'csv') {
+        data = jsonToCSV(output);
+        textContent = "CSV";
+      } else if (preferredFileType === 'ics') {
+        data = jsonToICal(output);
+        textContent = "ICalendar";
+      }
+      downloadFile(data, "schedule", preferredFileType);
+
+      // change the text content depending on the preferred file type
+      newTag.textContent = `${textContent} file (.${preferredFileType}) downloaded!`;
     }
     alertBox.appendChild(newTag);
   }
 });
 
+const fileTypeSelect = document.getElementById("fileType");
+let preferredFileType = fileTypeSelect.value;
+
+// change the value of fileTypeSelect whenever the value of the selection is changed
+fileTypeSelect.addEventListener("change", (e) => {
+    preferredFileType = e.target.value;
+    if (preferredFileType === 'csv') {
+        document.getElementById("dateInput").disabled = true;
+    } else {
+        document.getElementById("dateInput").disabled = false;
+    }
+    
+});
 
 /**
  *  sets the default value of the date input element
@@ -91,6 +117,7 @@ function separateSchedules(data) {
           const output = {
               subject: data[i].subject,
               "Start Date": getDayDate(days[0]),
+              "Scheduled Day": days[0], 
               "All Day Event": "FALSE",
               "Start Time": formatTime(times[0].split("-")[0]),
               "End Time": formatTime(times[0].split("-")[1]),
@@ -104,6 +131,7 @@ function separateSchedules(data) {
               const output = {
                   subject: data[i].subject,
                   "Start Date": getDayDate(days[j]),
+                  "Scheduled Day": days[j],
                   "All Day Event": "FALSE",
                   "Start Time": formatTime(times[j].split("-")[0]),
                   "End Time": formatTime(times[j].split("-")[1]),
@@ -191,17 +219,25 @@ function parseDateTime(dateStr, timeStr) {
 function formatICalDate(date) {
   return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
 }
-  
 
-// Function to download .ics file
-function downloadICS(content, filename) {
-  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
+// Function to download with the preferred file type
+function downloadFile(content, filename, fileType) {
+  
+  let contentType;
+  
+  if (fileType === 'csv') {
+    contentType = 'text/csv';
+  } else if (fileType === 'ics') {
+    contentType = 'text/calendar;charset=utf-8';
+  }
+
+  const blob = new Blob([content], {type: contentType});
   const url = URL.createObjectURL(blob);
   
   const a = document.createElement('a');
   a.style.display = 'none';
   a.href = url;
-  a.download = filename + '.ics';
+  a.download = filename + `.${fileType.toLowerCase()}`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
@@ -213,3 +249,89 @@ function formatTime(timeString) {
   const formattedTime = `${time} ${period.toUpperCase()}`;
   return formattedTime;
 }
+
+// converts 24-hr to 12-hr format
+function strtimeAMPM(date) {
+    let hour = date.getHours();
+    let min = date.getMinutes();
+
+    let ampm = hour >= 12 ? "PM" : "AM";
+    hour = hour % 12;
+    hour = hour === 0 ? 12 : hour;
+
+    return `${hour.toString().padStart(2, "0")}:${min.toString().padStart(2, "0")} ${ampm}`;
+
+}
+
+// generate an array of 30-minute timeslots from a given range
+function generateTimeslots(startHour, endHour) {
+
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+
+    const timeslots = [];
+
+    for (let i = 0; i < 48; i++) {
+
+        if (date.getHours() >= endHour) {
+            break;
+        }
+
+        if (date.getHours() >= startHour) {
+            timeslots.push(strtimeAMPM(date));
+        } 
+        
+        date.setMinutes(date.getMinutes() + 30);
+    }
+
+    return timeslots;
+}
+
+/**
+ * converts an object of schedules to a csv-compatible object
+ * 
+ * @param object - an object containing the rows of the extracted and separated schedule
+ * @returns an object compatible for conversion to csv file
+ */
+function jsonToCSV(output) {
+    
+    const timeslots = generateTimeslots(7, 22);
+
+    const fullDaysOfWeek = [
+        "Sunday", "Monday", "Tuesday", 
+        "Wednesday", "Thursday", "Friday", "Saturday"
+    ];
+
+    const daysOfWeek = ["SUN", "M", "T", "W", "TH", "F", "S"];
+
+    // get the days of the week as the header
+    const headers = ["", [...fullDaysOfWeek]];
+
+    const csv = [];
+    csv[0] = headers;
+
+    // 2d array [timeslots][7];
+    for (let i = 0; i < timeslots.length; i++) {
+        if (i + 1 < timeslots.length) {
+            csv.push([`${timeslots[i]} - ${timeslots[i+1]}`, "", "", "", "", "", "", ""]);
+        }
+    }
+
+    output.forEach(row => {
+        
+        // get all the needed values from the current row
+        let subjectTimeslotIdx = timeslots.indexOf(row["Start Time"]);
+        let dayIdx = daysOfWeek.indexOf(row["Scheduled Day"]);
+        let subject = row["subject"].toString().replace(",", "");
+
+        // set the start time to the end time's timeslot value to the current subject
+        // ex. (8:00 AM - 9:30 AM - <subject>)
+        while (timeslots[subjectTimeslotIdx] !== row["End Time"]) {
+            csv[subjectTimeslotIdx + 1][dayIdx + 1] = subject;
+            subjectTimeslotIdx++;
+        }
+
+    });
+
+    return csv.join('\n');
+};


### PR DESCRIPTION
I implemented a function to convert the `output` object generated from the `separateSchedules()` into a new object suitable for conversion to .csv file.

**Added**:

- function for JSON to CSV
- selection element with *.ics* and *.csv* as its available options

**Changed**:

- updated the `downloadICS()` function to `downloadFile()` with an additional parameter of `fileType`. This parameter allows the function to download the schedule in the preferred file type selected from the options
- some styling adjustments since I added the selection element beside the convert button
- disables the date input element if the selected file type is *.csv*

**Preview**:
![image](https://github.com/KevsterAmp/PUPSIS-Schedule-Exporter/assets/120155609/390da213-850f-435d-b871-1a0d6649379c)

**example.csv**:
![image](https://github.com/KevsterAmp/PUPSIS-Schedule-Exporter/assets/120155609/d71534a9-f1b8-4b03-bd29-ec612d94bbc0)
![image](https://github.com/KevsterAmp/PUPSIS-Schedule-Exporter/assets/120155609/76c1ce89-a9a7-413b-ab57-9249eef1a050)

**Recommendations**:
Masyadong mahaba name ng mga course kaya nasasakop na agad buong screen if inexpand bawat column WHAHAHA it would be better if we can also extract the subject code pero mukhang di available sa sched kaya i think this could still be modified with that in mind. Also, if this doesn't align with your intended use with this feature, please let me know!! 🙏 


